### PR TITLE
bug: fixed wrong apostrophe

### DIFF
--- a/network_check.sh
+++ b/network_check.sh
@@ -43,9 +43,9 @@ function restart_wlan {
     echo "Network was not working for the previous $network_check_tries checks."
     # We restart specified Wireless LAN
     echo "Restarting $nic"
-    /sbin/ifdown '$nic'
+    /sbin/ifdown "$nic"
     sleep 5
-    /sbin/ifup --force '$nic'
+    /sbin/ifup --force "$nic"
     sleep 60
     host_status=$(fping $gateway_ip)
     if [[ $host_status != *"alive"* ]]; then


### PR DESCRIPTION
Armbian Bionic
`/sbin/ifdown '$nic'` return 'unknown network $nic'
Changed apostrophe from ' ' to " ".
Now it's working fine.