### PR TITLE
Make ifupdown optional for udev users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - Edit your root user's crontab using:  
 `sudo crontab -e` 
 - Add to your crontab the following line, it will execute the check every minute. Please customize the script path according to the folder where you cloned the repo:  
-`* * * * * /yourpath/network_check.sh`
+`* * * * * /yourpath/network_check.sh >> /var/log/netcheck.log 2>&1`
 - If you also want to reboot in case wifi is not working after the fix customize the reboot_server variable accordigly editing the script:  
 `nano network_check.sh`  
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 ## Prerequisites
 
 - Download and install requirements:  
-`sudo apt-get install ifupdown fping -y`
+`sudo apt-get install fping -y`
+
+- Optional.  Note ifupdown isn't compatible with udev, which you may not be hip with replacing on your NAS OS
+`sudo apt-get install ifupdown -y`
 
 ## How to use
 

--- a/network_check.sh
+++ b/network_check.sh
@@ -5,7 +5,6 @@
 # Please check README.md for install / usage instructions
 
 # Checking if requirements (fping and ifupdown) are installed 
-set -xv
 `command -v /sbin/fping >/dev/null 2>&1 || command -v fping >/dev/null 2>&1` || { echo >&2 "Sorry but fping is not installed. Aborting.";  exit 1; }
 
 command -v /sbin/ifdown >/dev/null 2>&1 || command -v ifup >/dev/null 2>&1

--- a/network_check.sh
+++ b/network_check.sh
@@ -10,8 +10,6 @@
 command -v /sbin/ifdown >/dev/null 2>&1 || command -v ifup >/dev/null 2>&1
 USE_IFUPDOWN=$?
 
-clear
-
 ###
 # Configuration variables, customize if needed
 ###
@@ -33,10 +31,14 @@ reboot_server=false
 # Initializing the network check counter to zero
 network_check_tries=0
 
+function date_log {
+    echo "$(date +'%Y-%m-%d %T') $1"
+}
+
 function restart_wlan {
     # Trying wlan restart using ifdown / ifup
-    echo "Network was not working for the previous $network_check_tries checks."
-    echo "Restarting $nic"
+    date_log "Network was not working for the previous $network_check_tries checks."
+    date_log "Restarting $nic"
     if [[ $USE_IFUPDOWN = 0 ]]; then
         /sbin/ifdown "$nic"
         sleep 5
@@ -53,8 +55,8 @@ function restart_wlan {
     host_status=$(fping $gateway_ip)
     if [[ $host_status != *"alive"* ]]; then
         if [ "$reboot_server" = true ] ; then
-            echo "Network is still not working, rebooting."
-            reboot
+            date_log "Network is still not working, rebooting"
+            /sbin/reboot
         fi
     fi
 }
@@ -70,7 +72,7 @@ while [ $network_check_tries -lt $network_check_threshold ]; do
     
     if [[ $host_status == *"alive"* ]]; then
         # Network is up
-        echo "Network is working correctly" && exit 0
+        date_log "Network is working correctly" && exit 0
     else
         # Network is down
         echo "Network is down, failed check number $network_check_tries of $network_check_threshold"

--- a/network_check.sh
+++ b/network_check.sh
@@ -19,7 +19,7 @@ clear
 # Set gateway_ip to the gateway that you want to check to declare network working or not
 gateway_ip='1.1.1.1'
 # Set nic to your Network card name, as seen in ifconfig output
-nic='eth0'
+nic='wlan0'
 # Set network_check_threshold to the maximum number of failed checks
 network_check_threshold=5
 # Set reboot_server to true if you want to reboot as a last


### PR DESCRIPTION
So it seems that ifupdown isn't compatible with udev which I was reluctant to remove on my ReadyNAS OS.   Not sure what huge value you get vs ifconfig (maybe the --force? option) but it was easy enough to make it optional.    